### PR TITLE
Update links in Docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 Philip Loche, Henrik Stooß
 
+- Change links to GitHub in documentation (#485)
 - Move changelog test from ``tox`` to Gitlab CI (#483)
 - Move from Gitlab to GitHub (#1)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,13 +1,13 @@
 Getting involved
 ----------------
 
-Contribution via merge requests are always welcome. Source code is available from
-`GitLab`_. Before submitting a merge request, please read the `developer documentation`_
+Contribution via pull requests are always welcome. Source code is available from
+`GitHub`_. Before submitting a pull request, please read the `developer documentation`_
 and open an issue to discuss your changes. Use only the `main` branch for submitting
 your requests.
 
-.. _`developer documentation` : https://maicos-devel.gitlab.io/maicos/devdoc
-.. _`GitLab` : https://gitlab.com/maicos-devel/maicos/
+.. _`developer documentation` : https://maicos-devel.github.io/maicos/latest/devdoc
+.. _`GitHub` : https://github.com/maicos-devel/maicos/
 
 By contributing to MAICoS, you accept and agree to the following terms and conditions
 for your present and future contributions submitted to MAICoS. Except for the license
@@ -31,7 +31,7 @@ forked branch to your machine.
 
 .. code-block:: bash
 
-  git clone git@gitlab.com:your-user-name/maicos.git
+  git clone git@github.com:your-user-name/maicos.git
 
 Now you have a local version on your machine which you can install by
 
@@ -44,7 +44,7 @@ This install the package in development mode, making it importable globally and 
 you to edit the code and directly use the updated version.
 
 .. _Tox: https://tox.readthedocs.io/en/latest/
-.. _`MAICoS develop project` : https://gitlab.com/maicos-devel/maicos
+.. _`MAICoS develop project` : https://github.com/maicos-devel/maicos
 
 Useful developer scripts
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,12 @@ users can use the Python API for their day to day analysis or use the provided
 infrastructure to build their own analysis for interfacial and confined systems.
 
 Keep up to date with MAICoS news by following us on Twitter_. If you find an issue, you
-can report it on Gitlab_. You can also join the developer team on Discord_ to discuss
+can report it on GitHub_. You can also join the developer team on Discord_ to discuss
 possible improvements and usages of MAICoS.
 
 .. _`MDAnalysis`: https://www.mdanalysis.org
 .. _`Twitter`: https://twitter.com/maicos_analysis
-.. _`Gitlab`: https://gitlab.com/maicos-devel/maicos
+.. _`GitHub`: https://github.com/maicos-devel/maicos
 .. _`Discord`: https://discord.gg/mnrEQWVAed
 
 .. inclusion-readme-intro-end

--- a/docs/src/analysis-modules/index.rst
+++ b/docs/src/analysis-modules/index.rst
@@ -6,10 +6,10 @@ Analysis modules
 This is a list of all analysis modules provided by MAICoS. Note that we do not have an
 example section for each module. Instead, we refer to our :ref:`tutorial <usage-python>`
 and :ref:`userdoc-how-to`. Once you understand the basic structure taught there, you can
-work with all modules. If not, feel free to raise an issue in Gitlab_ or ask us on
+work with all modules. If not, feel free to raise an issue in GitHub_ or ask us on
 Discord_.
 
-.. _`Gitlab`: https://gitlab.com/maicos-devel/maicos/-/issues
+.. _`GitHub`: https://github.com/maicos-devel/maicos/issues
 .. _`Discord`: https://discord.gg/mnrEQWVAed
 
 .. toctree::

--- a/docs/src/devdoc/release.rst
+++ b/docs/src/devdoc/release.rst
@@ -76,4 +76,4 @@ After the release
 
 .. _`version` : https://pypi.org/project/versioneer
 .. _`upgrade notes` : https://github.com/python-versioneer/python-versioneer/blob/master/UPGRADING.md
-.. _`web interface` : https://gitlab.com/maicos-devel/maicos/-/tags
+.. _`web interface` : https://github.com/maicos-devel/maicos/releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ examples = ["matplotlib"]
 [project.urls]
 homepage = "https://www.maicos-analysis.org"
 documentation = "https://maicos-devel.gitlab.io/maicos"
-repository = "https://gitlab.com/maicos-devel/maicos"
-changelog = "https://maicos-devel.gitlab.io/maicos/get-started/changelog.html"
-issues = "https://gitlab.com/maicos-devel/maicos/-/issues"
+repository = "https://github.com/maicos-devel/maicos"
+changelog = "https://maicos-devel.github.io/maicos/latest/get-started/changelog.html"
+issues = "https://github.com/maicos-devel/maicos/issues"
 discord = "https://discord.gg/mnrEQWVAed"
 twitter = "https://twitter.com/maicos_analysis"
 


### PR DESCRIPTION
Changes made in this Pull Request:
 - Changed links from gitlab to github

<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--485.org.readthedocs.build/en/485/

<!-- readthedocs-preview maicos end -->