### PR TITLE
Update release workflow docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    tags: ["*"]
   pull_request:
     paths:
       # build wheels in PR if this file changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,11 @@ Changelog
   - keep the format consistent (88 char width, Y/M/D date format) and do not use tabs but
     use spaces for formatting
 
-.. Unreleased
-.. ----------
+Unreleased
+----------
+Philip Loche
+
+- Update release workflow documentation (#504)
 
 v0.11 (2025/06/25)
 ------------------

--- a/docs/src/devdoc/release.rst
+++ b/docs/src/devdoc/release.rst
@@ -34,45 +34,58 @@ Versioneer (optional)
 Create release
 --------------
 
-1. Make sure changelog is up to date and add release date and commit
-   your changes
+1. **Prepare a Release Pull Request**
 
-   .. code-block:: bash
+   - Based on the main branch create branch ``release-x.y.z`` and a PR.
+   - Ensure that all `CI tests
+     <https://github.com/maicos-devel/maicos/actions>`_ pass.
+   - Optionally, run the tests locally to double-check.
 
-    git commit -m 'Release vX.X'
+2. **Update the Changelog**
 
-2. Tag commit with the new version
+   Edit the changelog located in ``CHANGELOG`` and add the new version and the date of
+   the release.
 
-   .. code-block:: bash
+3. **Merge the PR and Create a Tag**
 
-    git tag -m 'Release vX.X' vX.X
+   - Merge the release PR.
+   - Update the ``main`` branch and check that the latest commit is the release PR with
+     ``git log``
+   - Create a tag on directly the ``main`` branch.
+   - Push the tag to GitHub. For example for a release of version ``x.y.z``:
 
-3. Test locally!!!
+     .. code-block:: bash
 
-   .. code-block:: bash
+        git checkout main
+        git pull
+        git tag -a vx.y.z -m "Release vx.y.z"
+        git push --tags
 
-    git describe
+4. **Trigger release workflow**
 
-   and
+   - Once the tag is pushed, navigate to the *Actions* tab of the repository.
+   - Select the ``Build`` workflow section.
+   - Click on the "Run workflow" dropdown and select the ``vx.y.z`` tag you just
+     created.
 
-   .. code-block:: bash
+5. **Finalize the GitHub Release**
 
-    pip3 install .
+   - The CI will automatically:
+      - Publish the package to PyPI.
+      - Create a draft release on GitHub.
+   - Update the GitHub release notes by pasting the changelog for the version.
 
-   should result in ``vX.X``
+6. **Merge Conda Recipe Changes**
 
-4. Push tag
-
-   .. code-block:: bash
-
-    git push --tags
-
-5. Go to the `web interface`_, add changelog as release message
+   - May resolve and then merge an automatically created PR on the `conda recipe
+     <https://github.com/conda-forge/maicos-feedstock>`_.
+   - Once thus PR is merged and the new version will be published automatically on the
+     `conda-forge <https://anaconda.org/conda-forge/maicos>`_ channel.
 
 After the release
 -----------------
 
-- Bump version (Create new section in CHANGELOG.rst)
+Add a placeholder section titled *Unreleased* for future updates.
 
 .. _`version` : https://pypi.org/project/versioneer
 .. _`upgrade notes` : https://github.com/python-versioneer/python-versioneer/blob/master/UPGRADING.md


### PR DESCRIPTION
Especially adding how to trigger the manual workflow to run the relase process.

I removed that the build process is run on tags from the `build.yml` because we anyway trigger this manually.

<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--504.org.readthedocs.build/en/504/

<!-- readthedocs-preview maicos end -->