### PR TITLE
Disable warnings in test output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 Philip Loche
 
+- Disable warnings in test output (#505)
 - Update release workflow documentation (#504)
 
 v0.11 (2025/06/25)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ addopts = [
     "--cov-append",
     "--cov-report=",
     "--import-mode=append",
+    "--disable-warnings",
 ]
 
 [tool.ruff]
@@ -141,10 +142,10 @@ ignore = [
     "D401",  # First line should be in imperative mood
     "D413",  # Missing blank line after last section
     "D417",  # Missing argument description in the docstring for {definition}: {name}
-    "TRY003", # Avoid specifying long messages outside the exception class
-    "TD003", # Missing issue link for this TODO
-    "G004", # f-strings in log messages
-    "LOG015", # Logging using root logger #TODO(@PicoCentauri): Check this
+    "TRY003",  # Avoid specifying long messages outside the exception class
+    "TD003",  # Missing issue link for this TODO
+    "G004",  # f-strings in log messages
+    "LOG015",  # Logging using root logger #TODO(@PicoCentauri): Check this
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     pytest {posargs}
 
     # Run documentation tests on all Python files and the README.rst
-    pytest --doctest-modules --disable-warnings --pyargs maicos
+    pytest --doctest-modules --pyargs maicos
 
 [testenv:lint]
 description = Run linters and type checks


### PR DESCRIPTION
Move the `disable-warnings` flag to the `pyproject.toml` to have it automatically applied to all `pytest` calls.

<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--505.org.readthedocs.build/en/505/

<!-- readthedocs-preview maicos end -->