### PR TITLE
Run a scheduled test on MDAnalysis dev version

### DIFF
--- a/.github/workflows/tests-dev.yml
+++ b/.github/workflows/tests-dev.yml
@@ -1,0 +1,27 @@
+name: Tests dev
+
+on:
+  schedule:
+    # check once a week on mondays
+    - cron: '0 10 * * 1'
+
+jobs:
+  tests-dev:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tests dependencies
+        run: python -m pip install tox
+
+      - name: Run tests against MDAnalysis dev version
+        run: tox -e tests-dev

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 Philip Loche
 
+- Run scheduled tests on MDAnalysis dev version (#506)
 - Disable warnings in test output (#505)
 - Update release workflow documentation (#504)
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,15 @@ commands =
     # Run documentation tests on all Python files and the README.rst
     pytest --doctest-modules --pyargs maicos
 
+[testenv:tests-dev]
+description = Run test suite against MDAnalysis dev version
+deps = 
+    -r tests/requirements.txt
+    MDAnalysis @ git+https://github.com/MDAnalysis/mdanalysis.git\#subdirectory=package
+    MDAnalysisTests @ git+https://github.com/MDAnalysis/mdanalysis.git\#subdirectory=testsuite
+commands =
+    pytest {posargs}
+
 [testenv:lint]
 description = Run linters and type checks
 package = skip


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #108

Changes made in this Pull Request:
 - Added tox entry for running tests against the main version of MDA
 - Run the test in the CI every Monday

PR Checklist
------------
 - [ ] Docs?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--506.org.readthedocs.build/en/506/

<!-- readthedocs-preview maicos end -->