### PR TITLE
Put module reference at the end of a doc page

### DIFF
--- a/docs/src/analysis-modules/densitycylinder.rst
+++ b/docs/src/analysis-modules/densitycylinder.rst
@@ -5,5 +5,4 @@ DensityCylinder
 
 .. autoclass:: maicos.DensityCylinder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/densityplanar.rst
+++ b/docs/src/analysis-modules/densityplanar.rst
@@ -7,5 +7,4 @@ DensityPlanar
 
 .. autoclass:: maicos.DensityPlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/densitysphere.rst
+++ b/docs/src/analysis-modules/densitysphere.rst
@@ -5,5 +5,4 @@ DensitySphere
 
 .. autoclass:: maicos.DensitySphere
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dielectriccylinder.rst
+++ b/docs/src/analysis-modules/dielectriccylinder.rst
@@ -5,5 +5,4 @@ DielectricCylinder
 
 .. autoclass:: maicos.DielectricCylinder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dielectricplanar.rst
+++ b/docs/src/analysis-modules/dielectricplanar.rst
@@ -5,5 +5,4 @@ DielectricPlanar
 
 .. autoclass:: maicos.DielectricPlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dielectricspectrum.rst
+++ b/docs/src/analysis-modules/dielectricspectrum.rst
@@ -5,5 +5,4 @@ DielectricSpectrum
 
 .. autoclass:: maicos.DielectricSpectrum
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dielectricsphere.rst
+++ b/docs/src/analysis-modules/dielectricsphere.rst
@@ -5,5 +5,4 @@ DielectricSphere
 
 .. autoclass:: maicos.DielectricSphere
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dipoleangle.rst
+++ b/docs/src/analysis-modules/dipoleangle.rst
@@ -5,5 +5,4 @@ DipoleAngle
 
 .. autoclass:: maicos.DipoleAngle
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dipordercylinder.rst
+++ b/docs/src/analysis-modules/dipordercylinder.rst
@@ -5,5 +5,4 @@ DiporderCylinder
 
 .. autoclass:: maicos.DiporderCylinder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/diporderplanar.rst
+++ b/docs/src/analysis-modules/diporderplanar.rst
@@ -5,5 +5,4 @@ DiporderPlanar
 
 .. autoclass:: maicos.DiporderPlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/dipordersphere.rst
+++ b/docs/src/analysis-modules/dipordersphere.rst
@@ -5,5 +5,4 @@ DiporderSphere
 
 .. autoclass:: maicos.DiporderSphere
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/diporderstructurefactor.rst
+++ b/docs/src/analysis-modules/diporderstructurefactor.rst
@@ -5,5 +5,4 @@ DiporderStructureFactor
 
 .. autoclass:: maicos.DiporderStructureFactor
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/kineticenergy.rst
+++ b/docs/src/analysis-modules/kineticenergy.rst
@@ -5,5 +5,4 @@ KineticEnergy
 
 .. autoclass:: maicos.KineticEnergy
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/pdfcylinder.rst
+++ b/docs/src/analysis-modules/pdfcylinder.rst
@@ -3,7 +3,6 @@
 PDFCylinder
 ###########
 
-.. autoclass:: maicos.modules.pdfcylinder.PDFCylinder
+.. autoclass:: maicos.PDFCylinder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/pdfplanar.rst
+++ b/docs/src/analysis-modules/pdfplanar.rst
@@ -5,5 +5,4 @@ PDFPlanar
 
 .. autoclass:: maicos.PDFPlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/rdfdiporder.rst
+++ b/docs/src/analysis-modules/rdfdiporder.rst
@@ -5,5 +5,4 @@ RDFDiporder
 
 .. autoclass:: maicos.RDFDiporder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/saxs.rst
+++ b/docs/src/analysis-modules/saxs.rst
@@ -5,5 +5,4 @@ Saxs
 
 .. autoclass:: maicos.Saxs
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/temperatureplanar.rst
+++ b/docs/src/analysis-modules/temperatureplanar.rst
@@ -5,5 +5,4 @@ TemperaturePlanar
 
 .. autoclass:: maicos.TemperaturePlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/velocitycylinder.rst
+++ b/docs/src/analysis-modules/velocitycylinder.rst
@@ -5,5 +5,4 @@ VelocityCylinder
 
 .. autoclass:: maicos.VelocityCylinder
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/analysis-modules/velocityplanar.rst
+++ b/docs/src/analysis-modules/velocityplanar.rst
@@ -5,5 +5,4 @@ VelocityPlanar
 
 .. autoclass:: maicos.VelocityPlanar
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/base/analysisbase.rst
+++ b/docs/src/api-documentation/base/analysisbase.rst
@@ -5,5 +5,4 @@ AnalysisBase
 
 .. autoclass:: maicos.core.AnalysisBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/base/analysiscollection.rst
+++ b/docs/src/api-documentation/base/analysiscollection.rst
@@ -5,5 +5,4 @@ AnalysisCollection
 
 .. autoclass:: maicos.core.AnalysisCollection
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/base/profilebase.rst
+++ b/docs/src/api-documentation/base/profilebase.rst
@@ -5,5 +5,4 @@ ProfileBase
 
 .. autoclass:: maicos.core.ProfileBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/cylinder/cylinderbase.rst
+++ b/docs/src/api-documentation/cylinder/cylinderbase.rst
@@ -5,5 +5,4 @@ CylinderBase
 
 .. autoclass:: maicos.core.CylinderBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/cylinder/profilecylinderbase.rst
+++ b/docs/src/api-documentation/cylinder/profilecylinderbase.rst
@@ -5,5 +5,4 @@ ProfileCylinderBase
 
 .. autoclass:: maicos.core.ProfileCylinderBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/math.rst
+++ b/docs/src/api-documentation/math.rst
@@ -5,10 +5,8 @@ Mathematical helper functions
 
 .. automodule:: maicos.lib.math
     :members:
-    :undoc-members:
     :show-inheritance:
 
 .. automodule:: maicos.lib._cmath
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/planar/planarbase.rst
+++ b/docs/src/api-documentation/planar/planarbase.rst
@@ -5,5 +5,4 @@ PlanarBase
 
 .. autoclass:: maicos.core.PlanarBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/planar/profileplanarbase.rst
+++ b/docs/src/api-documentation/planar/profileplanarbase.rst
@@ -5,5 +5,4 @@ ProfilePlanarBase
 
 .. autoclass:: maicos.core.ProfilePlanarBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/sphere/profilespherebase.rst
+++ b/docs/src/api-documentation/sphere/profilespherebase.rst
@@ -5,5 +5,4 @@ ProfileSphereBase
 
 .. autoclass:: maicos.core.ProfileSphereBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/sphere/spherebase.rst
+++ b/docs/src/api-documentation/sphere/spherebase.rst
@@ -5,5 +5,4 @@ SphereBase
 
 .. autoclass:: maicos.core.SphereBase
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/util.rst
+++ b/docs/src/api-documentation/util.rst
@@ -5,5 +5,4 @@ General helper functions
 
 .. automodule:: maicos.lib.util
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/api-documentation/weights.rst
+++ b/docs/src/api-documentation/weights.rst
@@ -5,5 +5,4 @@ Weighting functions
 
 .. automodule:: maicos.lib.weights
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/src/devdoc/documentation.rst
+++ b/docs/src/devdoc/documentation.rst
@@ -42,11 +42,13 @@ following format:
 
     .. autoclass:: maicos.ModuleName
         :members:
-        :undoc-members:
         :show-inheritance:
 
-Note that all files located within ``docs/src/examples`` are generated from the Python
-scrips located in ``examples`` using `Sphinx-Gallery`_.
+We use the ``:members:`` directive to include inherited methods and attributes like the
+``save`` method.
+
+All files located within ``docs/src/examples`` are generated from the Python scrips
+located in ``examples`` using `Sphinx-Gallery`_.
 
 .. _`Sphinx` : https://www.sphinx-doc.org/en/master/
 .. _`Sphinx-Gallery` : https://sphinx-gallery.github.io/stable/index.html


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Trying to fix #496 

Removing the `:undoc-members:` as suggested is a nice cleanup but does not solve the issue.


<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--507.org.readthedocs.build/en/507/

<!-- readthedocs-preview maicos end -->