### PR TITLE
Add united atom to electron density calculations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,11 @@ Changelog
   - keep the format consistent (88 char width, Y/M/D date format) and do not use tabs but
     use spaces for formatting
 
-.. Unreleased
-.. ----------
+Unreleased
+----------
+Philip Loche
+
+- Add united atom elements to electron density calculations (#509)
 
 v0.11.1 (2025/07/04)
 --------------------

--- a/tests/lib/test_weights.py
+++ b/tests/lib/test_weights.py
@@ -118,6 +118,22 @@ def test_density_weights_electron_title():
     )
 
 
+@pytest.mark.parametrize(
+    ("element", "n_electrons"),
+    [("CH1", 7), ("CH2", 8), ("CH3", 9), ("NH1", 8), ("NH2", 9), ("NH3", 10)],
+)
+def test_density_weights_electron_united_atoms(element, n_electrons):
+    """Test electron weights also for work for united atom force fields."""
+    u = mda.Universe(SPCE_GRO)
+    u.add_TopologyAttr("elements", u.atoms.n_atoms * [element])
+
+    assert_allclose(
+        maicos.lib.weights.density_weights(u.atoms, "atoms", "electron"),
+        n_electrons * np.ones(u.atoms.n_atoms, dtype=np.float64),
+        rtol=1e-3,
+    )
+
+
 def test_density_weights_electron_error():
     """Test error raise for non existing element."""
     u = mda.Universe(SPCE_GRO)


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->


Changes made in this Pull Request:
 - Add support for united atom elements to the electron density calculations.

PR Checklist
------------
 - [ ] Docs?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--510.org.readthedocs.build/en/510/

<!-- readthedocs-preview maicos end -->