### PR TITLE
Cleanup build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,9 @@ jobs:
           check-latest: true
 
       - name: Install dependencies
-        run: python -m pip install wheel build tox
+        run: python -m pip install tox
 
-      - name: Build sdist
-        run: python -m build --sdist --outdir dist .
-
-      - name: Test build integrity
+      - name: Test build integrity and create sdist
         run: tox -e build
 
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 Philip Loche
 
+- Small cleanup of build workflow (#521)
 - Minor streamlining of CI workflows (#515)
 - Update Python wheels building (#514)
 


### PR DESCRIPTION
the tox build tasked already creates the sdist distribution. No need to add an extra step for it in the CI.

<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--521.org.readthedocs.build/en/521/

<!-- readthedocs-preview maicos end -->