### PR TITLE
Remove unusued diporder_pair_weights

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 ----------
 Philip Loche, Kira Fischer, Francis Jose, Philipp Staerk, Henrik Stooß
 
+- Remove ``diporder_pair_weights`` function (#531)
 - Update issue templates (#530)
 - Move ``DielectricSpectrum``, ``lib.math.FT``, ``lib.math.iFT`` to spectrakit package.
   (#524)

--- a/src/maicos/lib/weights.py
+++ b/src/maicos/lib/weights.py
@@ -178,19 +178,6 @@ def diporder_weights(
     return weights
 
 
-def diporder_pair_weights(
-    g1: mda.AtomGroup, g2: mda.AtomGroup, compound: str
-) -> np.ndarray:
-    """Normalized dipole moments as weights for general diporder RDF calculations."""
-    dipoles_1 = g1.dipole_vector(compound=compound)
-    dipoles_2 = g2.dipole_vector(compound=compound)
-
-    dipoles_1 /= np.linalg.norm(dipoles_1, axis=1)[:, np.newaxis]
-    dipoles_2 /= np.linalg.norm(dipoles_2, axis=1)[:, np.newaxis]
-
-    return dipoles_1 @ dipoles_2.T
-
-
 @render_docs
 def velocity_weights(atomgroup: mda.AtomGroup, grouping: str, vdim: int) -> np.ndarray:
     """Weights for velocity calculations.

--- a/tests/lib/test_weights.py
+++ b/tests/lib/test_weights.py
@@ -28,7 +28,6 @@ from data import (  # noqa: E402
     WATER_TPR_NPT,
     WATER_TRR_NPT,
 )
-from util import line_of_water_molecules  # noqa: E402
 
 
 @pytest.fixture
@@ -158,30 +157,6 @@ def test_tempetaure_weights_grouping(ag_water_npt, grouping):
     """Test when grouping != atoms."""
     with pytest.raises(NotImplementedError):
         maicos.lib.weights.temperature_weights(ag_water_npt, grouping)
-
-
-def test_diporder_pair_weights_single(ag_spce):
-    """Test that the weight of the same molecules is equal to one 1."""
-    weights = maicos.lib.weights.diporder_pair_weights(
-        ag_spce, ag_spce, compound="residues"
-    )
-    assert_allclose(weights, 1)
-
-
-def test_diporder_pair_weights_line():
-    """Test that the weight of the same molecules is equal to one 1."""
-    ag = line_of_water_molecules(n_molecules=4, angle_deg=[0.0, 45.0, 90.0, 180.0])
-    weights = maicos.lib.weights.diporder_pair_weights(ag, ag, compound="residues")
-
-    weights_expected = np.array(
-        [
-            [1.00, 0.71, 0.00, -1.00],
-            [0.71, 1.00, 0.71, -0.71],
-            [0.00, 0.71, 1.00, 0.00],
-            [-1.00, -0.71, 0.00, 1.00],
-        ]
-    )
-    assert_equal(weights.round(2), weights_expected)
 
 
 class Testdiporder_weights:


### PR DESCRIPTION
Moved to `scatterkit` in https://github.com/maicos-devel/scatterkit/pull/2

<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--532.org.readthedocs.build/en/532/

<!-- readthedocs-preview maicos end -->