### PR TITLE
Populate benchmark suite (#590)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,7 @@ Unreleased
 Alexander Schlaich, Henrik Stooß, Anirban Dutta, Philip Loche, Kira Fischer,
 Lucas Kleindienst, Philipp Stärk, Leo Legrand
 
-- Add per-module atom-count scaling benchmarks (``bench_atom_scaling.py``) using
-  synthetic in-memory universes to measure ``_single_frame`` cost for all 14 analysis
-  modules (#590)
+- Add per-module atom-count scaling benchmarks (``bench_atom_scaling.py``) (#590)
 - Remove ``inplace`` parameter from :func:`maicos.lib.math.symmetrize`; the
   function now always returns a new ``float`` array without modifying the input
 - Add function and example how to use times instead of frame slices (#585)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Unreleased
 Alexander Schlaich, Henrik Stooß, Anirban Dutta, Philip Loche, Kira Fischer,
 Lucas Kleindienst, Philipp Stärk, Leo Legrand
 
+- Add per-module atom-count scaling benchmarks (``bench_atom_scaling.py``) using
+  synthetic in-memory universes to measure ``_single_frame`` cost for all 14 analysis
+  modules (#590)
 - Add function and example how to use times instead of frame slices (#585)
 - Refactor diporder modules to use Legendre polynomials (#586)
 - Treat all warnings as error in tests (#575)

--- a/benchmarks/core/bench_base.py
+++ b/benchmarks/core/bench_base.py
@@ -80,7 +80,7 @@ class SingleFrameBenchmark:
         if transform == "pack":
             return {"pack": True}
         if transform == "unwrap":
-            return {"unwrap": True, "wrap_compound": "atoms"}
+            return {"unwrap": True, "wrap_compound": "residues"}
         if transform == "refgroup":
             # the framework requires pack when a refgroup is set
             half = self.atomgroup[: len(self.atomgroup) // 2]

--- a/benchmarks/core/bench_base.py
+++ b/benchmarks/core/bench_base.py
@@ -9,23 +9,84 @@
 
 import numpy as np
 
+from benchmarks.synthetic import make_universe
 from maicos.core import AnalysisBase
 
 
-class AnalysisBaseBenchmark(AnalysisBase):
+class _RandomObs(AnalysisBase):
     """Minimal analysis that writes random observables — measures framework overhead."""
 
-    def __init__(self, atomgroup, n_obs=10):
+    def __init__(self, atomgroup, n_obs=10, **kwargs):
         self._n_obs = n_obs
-        super().__init__(
-            atomgroup=atomgroup,
-            unwrap=False,
-            pack=False,
-            refgroup=None,
-            jitter=0.0,
-            wrap_compound="atoms",
-            concfreq=0,
-        )
+        kwargs.setdefault("unwrap", False)
+        kwargs.setdefault("pack", False)
+        kwargs.setdefault("refgroup", None)
+        kwargs.setdefault("jitter", 0.0)
+        kwargs.setdefault("wrap_compound", "atoms")
+        kwargs.setdefault("concfreq", 0)
+        super().__init__(atomgroup=atomgroup, **kwargs)
 
     def _single_frame(self):
-        self._obs.data = np.random.rand(self._n_obs)
+        for i in range(self._n_obs):
+            self._obs[f"obs{i}"] = np.random.rand()
+
+
+class AnalysisBaseBenchmark:
+    """Direct framework overhead of :class:`AnalysisBase` with no real analysis."""
+
+    timeout = 120
+
+    def setup(self):
+        """Build the synthetic atomgroup."""
+        self.atomgroup = make_universe()
+
+    def time_run(self):
+        """Time a bare run over the trajectory."""
+        _RandomObs(self.atomgroup).run()
+
+    def peakmem_run(self):
+        """Peak memory of a bare run over the trajectory."""
+        _RandomObs(self.atomgroup).run()
+
+
+class ObsAccumulationBenchmark:
+    """Observable-accumulation overhead as the number of ``_obs`` entries grows."""
+
+    timeout = 180
+    params = [1, 10, 100, 1000]
+    param_names = ["n_obs"]
+
+    def setup(self, _n_obs):
+        """Build the synthetic atomgroup."""
+        self.atomgroup = make_universe()
+
+    def time_run(self, n_obs):
+        """Time a run accumulating ``n_obs`` observables per frame."""
+        _RandomObs(self.atomgroup, n_obs=n_obs).run()
+
+
+class SingleFrameBenchmark:
+    """Marginal cost of the per-frame transforms (pack, unwrap, refgroup)."""
+
+    timeout = 180
+    params = ["none", "pack", "unwrap", "refgroup"]
+    param_names = ["transform"]
+
+    def setup(self, _transform):
+        """Build the synthetic atomgroup."""
+        self.atomgroup = make_universe()
+
+    def _kwargs(self, transform):
+        if transform == "pack":
+            return {"pack": True}
+        if transform == "unwrap":
+            return {"unwrap": True, "wrap_compound": "atoms"}
+        if transform == "refgroup":
+            # the framework requires pack when a refgroup is set
+            half = self.atomgroup[: len(self.atomgroup) // 2]
+            return {"refgroup": half, "pack": True}
+        return {}
+
+    def time_run(self, transform):
+        """Time a run applying the selected per-frame transform."""
+        _RandomObs(self.atomgroup, n_obs=1, **self._kwargs(transform)).run()

--- a/benchmarks/core/bench_profile.py
+++ b/benchmarks/core/bench_profile.py
@@ -10,17 +10,24 @@
 from benchmarks.synthetic import make_universe
 from maicos import DensityPlanar, DielectricPlanar
 
+N_ATOMS = 30_000
+
 
 class ProfileBinBenchmark:
-    """ProfileBase scaling with the number of bins (via ``bin_width``)."""
+    """ProfileBase scaling with the number of bins (via ``bin_width``).
+
+    :func:`numpy.histogram` is linear in the atom count and nearly independent of the
+    bin count, so the bin widths have to reach far below the box resolution before the
+    number of bins overtakes it.
+    """
 
     timeout = 180
-    params = [2.0, 1.0, 0.5, 0.1]
+    params = [1.0, 0.1, 0.01, 0.001]
     param_names = ["bin_width"]
 
     def setup(self, _bin_width):
         """Build the synthetic atomgroup."""
-        self.atomgroup = make_universe()
+        self.atomgroup = make_universe(n_atoms=N_ATOMS)
 
     def time_run(self, bin_width):
         """Time DensityPlanar over a range of bin widths."""
@@ -34,15 +41,20 @@ class ProfileBinBenchmark:
 
 
 class DielectricBinBenchmark:
-    """Dielectric scaling with the number of bins (via ``bin_width``)."""
+    """Dielectric scaling with the number of bins (via ``bin_width``).
+
+    The bin widths stop well above those of :class:`ProfileBinBenchmark` because the
+    virtual cut kernel allocates ``n_bins * box / vcutwidth`` entries per frame and per
+    direction parallel to the surface.
+    """
 
     timeout = 180
-    params = [2.0, 1.0, 0.5, 0.1]
+    params = [1.0, 0.5, 0.1, 0.05, 0.02]
     param_names = ["bin_width"]
 
     def setup(self, _bin_width):
         """Build the synthetic atomgroup."""
-        self.atomgroup = make_universe()
+        self.atomgroup = make_universe(n_atoms=N_ATOMS)
 
     def time_run(self, bin_width):
         """Time DielectricPlanar over a range of bin widths."""

--- a/benchmarks/core/bench_profile.py
+++ b/benchmarks/core/bench_profile.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Bin-dependent benchmarks for profile-based analyses on synthetic data."""
+
+from benchmarks.synthetic import make_universe
+from maicos import DensityPlanar, DielectricPlanar
+
+
+class ProfileBinBenchmark:
+    """ProfileBase scaling with the number of bins (via ``bin_width``)."""
+
+    timeout = 180
+    params = [2.0, 1.0, 0.5, 0.1]
+    param_names = ["bin_width"]
+
+    def setup(self, _bin_width):
+        """Build the synthetic atomgroup."""
+        self.atomgroup = make_universe()
+
+    def time_run(self, bin_width):
+        """Time DensityPlanar over a range of bin widths."""
+        DensityPlanar(
+            self.atomgroup,
+            dens="mass",
+            bin_width=bin_width,
+            unwrap=False,
+            pack=False,
+        ).run()
+
+
+class DielectricBinBenchmark:
+    """Dielectric scaling with the number of bins (via ``bin_width``)."""
+
+    timeout = 180
+    params = [2.0, 1.0, 0.5, 0.1]
+    param_names = ["bin_width"]
+
+    def setup(self, _bin_width):
+        """Build the synthetic atomgroup."""
+        self.atomgroup = make_universe()
+
+    def time_run(self, bin_width):
+        """Time DielectricPlanar over a range of bin widths."""
+        DielectricPlanar(
+            self.atomgroup,
+            bin_width=bin_width,
+            unwrap=False,
+            pack=False,
+        ).run()

--- a/benchmarks/modules/bench_atom_scaling.py
+++ b/benchmarks/modules/bench_atom_scaling.py
@@ -42,6 +42,11 @@ def _make(n_atoms):
     return make_universe(n_atoms=n_atoms, n_frames=1, n_residues=n_atoms // 3)
 
 
+# ---------------------------------------------------------------------------
+# Density
+# ---------------------------------------------------------------------------
+
+
 class DensityPlanarAtomScaling:
     """_single_frame cost of DensityPlanar vs. atom count."""
 
@@ -50,10 +55,14 @@ class DensityPlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
-        DensityPlanar(self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False).run()
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
+        DensityPlanar(
+            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
+        ).run()
 
 
 class DensityCylinderAtomScaling:
@@ -64,9 +73,11 @@ class DensityCylinderAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DensityCylinder(
             self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
         ).run()
@@ -80,12 +91,19 @@ class DensitySphereAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DensitySphere(
             self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
         ).run()
+
+
+# ---------------------------------------------------------------------------
+# Dielectric
+# ---------------------------------------------------------------------------
 
 
 class DielectricPlanarAtomScaling:
@@ -96,9 +114,11 @@ class DielectricPlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DielectricPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -110,9 +130,11 @@ class DielectricCylinderAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DielectricCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -124,10 +146,17 @@ class DielectricSphereAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DielectricSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+# ---------------------------------------------------------------------------
+# Diporder
+# ---------------------------------------------------------------------------
 
 
 class DiporderPlanarAtomScaling:
@@ -138,9 +167,11 @@ class DiporderPlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DiporderPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -152,9 +183,11 @@ class DiporderCylinderAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DiporderCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -166,10 +199,17 @@ class DiporderSphereAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         DiporderSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+# ---------------------------------------------------------------------------
+# Temperature / Velocity
+# ---------------------------------------------------------------------------
 
 
 class TemperaturePlanarAtomScaling:
@@ -180,9 +220,11 @@ class TemperaturePlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         TemperaturePlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -194,9 +236,11 @@ class VelocityPlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         VelocityPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -208,11 +252,17 @@ class VelocityCylinderAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         VelocityCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
+
+# ---------------------------------------------------------------------------
+# PDF  (O(N²) kernel — capped at 3000 atoms)
+# ---------------------------------------------------------------------------
 
 
 class PDFPlanarAtomScaling:
@@ -223,9 +273,11 @@ class PDFPlanarAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         PDFPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
 
 
@@ -237,7 +289,9 @@ class PDFCylinderAtomScaling:
     param_names = ["n_atoms"]
 
     def setup(self, n_atoms):
+        """Build the synthetic atomgroup."""
         self.ag = _make(n_atoms)
 
-    def time_single_frame(self, n_atoms):
+    def time_single_frame(self, _n_atoms):
+        """Time a single-frame run."""
         PDFCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()

--- a/benchmarks/modules/bench_atom_scaling.py
+++ b/benchmarks/modules/bench_atom_scaling.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Per-module ``_single_frame`` cost as a function of atom count.
+
+Each class benchmarks one module over a 1-frame synthetic universe at
+``n_atoms`` in [300, 1000, 3000, 10000] (PDF modules use [300, 1000, 3000]
+because their O(N²) pairwise kernel makes 10 k atoms prohibitively slow).
+
+``unwrap=False, pack=False`` are passed wherever possible to isolate the
+analysis kernel from coordinate-transform overhead.
+"""
+
+from benchmarks.synthetic import make_universe
+from maicos import (
+    DensityCylinder,
+    DensityPlanar,
+    DensitySphere,
+    DielectricCylinder,
+    DielectricPlanar,
+    DielectricSphere,
+    DiporderCylinder,
+    DiporderPlanar,
+    DiporderSphere,
+    PDFCylinder,
+    PDFPlanar,
+    TemperaturePlanar,
+    VelocityCylinder,
+    VelocityPlanar,
+)
+
+_N_ATOMS = [300, 1000, 3000, 10000]
+_N_ATOMS_PDF = [300, 1000, 3000]
+
+
+def _make(n_atoms):
+    """1-frame synthetic atomgroup with water-like residue layout."""
+    return make_universe(n_atoms=n_atoms, n_frames=1, n_residues=n_atoms // 3)
+
+
+class DensityPlanarAtomScaling:
+    """_single_frame cost of DensityPlanar vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DensityPlanar(self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DensityCylinderAtomScaling:
+    """_single_frame cost of DensityCylinder vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DensityCylinder(
+            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
+        ).run()
+
+
+class DensitySphereAtomScaling:
+    """_single_frame cost of DensitySphere vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DensitySphere(
+            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
+        ).run()
+
+
+class DielectricPlanarAtomScaling:
+    """_single_frame cost of DielectricPlanar vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DielectricPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DielectricCylinderAtomScaling:
+    """_single_frame cost of DielectricCylinder vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DielectricCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DielectricSphereAtomScaling:
+    """_single_frame cost of DielectricSphere vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DielectricSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DiporderPlanarAtomScaling:
+    """_single_frame cost of DiporderPlanar vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DiporderPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DiporderCylinderAtomScaling:
+    """_single_frame cost of DiporderCylinder vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DiporderCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class DiporderSphereAtomScaling:
+    """_single_frame cost of DiporderSphere vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        DiporderSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class TemperaturePlanarAtomScaling:
+    """_single_frame cost of TemperaturePlanar vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        TemperaturePlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class VelocityPlanarAtomScaling:
+    """_single_frame cost of VelocityPlanar vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        VelocityPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class VelocityCylinderAtomScaling:
+    """_single_frame cost of VelocityCylinder vs. atom count."""
+
+    timeout = 300
+    params = _N_ATOMS
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        VelocityCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+
+class PDFPlanarAtomScaling:
+    """_single_frame cost of PDFPlanar vs. atom count (O(N²), capped at 3000)."""
+
+    timeout = 600
+    params = _N_ATOMS_PDF
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        PDFPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+
+
+class PDFCylinderAtomScaling:
+    """_single_frame cost of PDFCylinder vs. atom count (O(N²), capped at 3000)."""
+
+    timeout = 600
+    params = _N_ATOMS_PDF
+    param_names = ["n_atoms"]
+
+    def setup(self, n_atoms):
+        self.ag = _make(n_atoms)
+
+    def time_single_frame(self, n_atoms):
+        PDFCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()

--- a/benchmarks/modules/bench_atom_scaling.py
+++ b/benchmarks/modules/bench_atom_scaling.py
@@ -7,13 +7,18 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Per-module ``_single_frame`` cost as a function of atom count.
 
-Each class benchmarks one module over a 1-frame synthetic universe at
-``n_atoms`` in [300, 1000, 3000, 10000] (PDF modules use [300, 1000, 3000]
-because their O(N²) pairwise kernel makes 10 k atoms prohibitively slow).
+``setup`` builds a one-frame synthetic universe and runs the analysis over it, which
+initialises every attribute the per-frame kernel needs. The benchmark itself then calls
+``_single_frame`` alone, so neither the trajectory loop nor the coordinate transforms
+(``unwrap``, ``pack``) are timed. The pair distribution modules get their own class
+because their pairwise kernels need smaller systems to stay within the time budget.
 
-``unwrap=False, pack=False`` are passed wherever possible to isolate the
-analysis kernel from coordinate-transform overhead.
+The single frame makes :func:`maicos.lib.util.correlation_analysis` warn about the
+trajectory being too short, which is expected here and muted so that it does not drown
+the benchmark output.
 """
+
+import warnings
 
 from benchmarks.synthetic import make_universe
 from maicos import (
@@ -33,265 +38,49 @@ from maicos import (
     VelocityPlanar,
 )
 
-_N_ATOMS = [300, 1000, 3000, 10000]
-_N_ATOMS_PDF = [300, 1000, 3000]
+LINEAR = (
+    DensityCylinder,
+    DensityPlanar,
+    DensitySphere,
+    DielectricCylinder,
+    DielectricPlanar,
+    DielectricSphere,
+    DiporderCylinder,
+    DiporderPlanar,
+    DiporderSphere,
+    TemperaturePlanar,
+    VelocityCylinder,
+    VelocityPlanar,
+)
+PAIRWISE = (PDFCylinder, PDFPlanar)
+MODULES = {cls.__name__: cls for cls in LINEAR + PAIRWISE}
 
 
-def _make(n_atoms):
-    """1-frame synthetic atomgroup with water-like residue layout."""
-    return make_universe(n_atoms=n_atoms, n_frames=1, n_residues=n_atoms // 3)
-
-
-# ---------------------------------------------------------------------------
-# Density
-# ---------------------------------------------------------------------------
-
-
-class DensityPlanarAtomScaling:
-    """_single_frame cost of DensityPlanar vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DensityPlanar(
-            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
-        ).run()
-
-
-class DensityCylinderAtomScaling:
-    """_single_frame cost of DensityCylinder vs. atom count."""
+class _AtomScaling:
+    """Time ``_single_frame`` of a prepared analysis over growing atom counts."""
 
     timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
+    param_names = ["module", "n_atoms"]
 
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
+    def setup(self, module, n_atoms):
+        """Build a one-frame universe and prepare the analysis on it."""
+        self.analysis = MODULES[module](make_universe(n_atoms=n_atoms, n_frames=1))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.analysis.run()
 
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DensityCylinder(
-            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
-        ).run()
+    def time_single_frame(self, _module, _n_atoms):
+        """Time one call of the per-frame kernel."""
+        self.analysis._single_frame()
 
 
-class DensitySphereAtomScaling:
-    """_single_frame cost of DensitySphere vs. atom count."""
+class AtomScaling(_AtomScaling):
+    """Atom-count scaling of the modules whose kernel is linear in the atom count."""
 
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
+    params = [[cls.__name__ for cls in LINEAR], [3_000, 10_000, 30_000, 100_000]]
 
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
 
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DensitySphere(
-            self.ag, dens="mass", bin_width=1.0, unwrap=False, pack=False
-        ).run()
+class PairwiseAtomScaling(_AtomScaling):
+    """Atom-count scaling of the pairwise pair distribution modules."""
 
-
-# ---------------------------------------------------------------------------
-# Dielectric
-# ---------------------------------------------------------------------------
-
-
-class DielectricPlanarAtomScaling:
-    """_single_frame cost of DielectricPlanar vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DielectricPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class DielectricCylinderAtomScaling:
-    """_single_frame cost of DielectricCylinder vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DielectricCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class DielectricSphereAtomScaling:
-    """_single_frame cost of DielectricSphere vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DielectricSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-# ---------------------------------------------------------------------------
-# Diporder
-# ---------------------------------------------------------------------------
-
-
-class DiporderPlanarAtomScaling:
-    """_single_frame cost of DiporderPlanar vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DiporderPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class DiporderCylinderAtomScaling:
-    """_single_frame cost of DiporderCylinder vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DiporderCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class DiporderSphereAtomScaling:
-    """_single_frame cost of DiporderSphere vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        DiporderSphere(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-# ---------------------------------------------------------------------------
-# Temperature / Velocity
-# ---------------------------------------------------------------------------
-
-
-class TemperaturePlanarAtomScaling:
-    """_single_frame cost of TemperaturePlanar vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        TemperaturePlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class VelocityPlanarAtomScaling:
-    """_single_frame cost of VelocityPlanar vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        VelocityPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class VelocityCylinderAtomScaling:
-    """_single_frame cost of VelocityCylinder vs. atom count."""
-
-    timeout = 300
-    params = _N_ATOMS
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        VelocityCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-# ---------------------------------------------------------------------------
-# PDF  (O(N²) kernel — capped at 3000 atoms)
-# ---------------------------------------------------------------------------
-
-
-class PDFPlanarAtomScaling:
-    """_single_frame cost of PDFPlanar vs. atom count (O(N²), capped at 3000)."""
-
-    timeout = 600
-    params = _N_ATOMS_PDF
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        PDFPlanar(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
-
-
-class PDFCylinderAtomScaling:
-    """_single_frame cost of PDFCylinder vs. atom count (O(N²), capped at 3000)."""
-
-    timeout = 600
-    params = _N_ATOMS_PDF
-    param_names = ["n_atoms"]
-
-    def setup(self, n_atoms):
-        """Build the synthetic atomgroup."""
-        self.ag = _make(n_atoms)
-
-    def time_single_frame(self, _n_atoms):
-        """Time a single-frame run."""
-        PDFCylinder(self.ag, bin_width=1.0, unwrap=False, pack=False).run()
+    params = [[cls.__name__ for cls in PAIRWISE], [1_500, 3_000, 6_000, 12_000]]

--- a/benchmarks/modules/bench_dipordercylinder.py
+++ b/benchmarks/modules/bench_dipordercylinder.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.DiporderCylinder`."""
+
+import MDAnalysis as mda
+
+from maicos import DiporderCylinder
+from tests.data import WATER_TPR_NPT, WATER_TRR_NPT
+
+
+class DiporderCylinderBenchmark:
+    """Benchmark the DiporderCylinder class."""
+
+    timeout = 120
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(WATER_TPR_NPT, WATER_TRR_NPT)
+        self.atomgroup = self.universe.select_atoms("resname SOL")
+
+    def time_diporder_cylinder_run(self):
+        """Benchmark DiporderCylinder.run() over the trajectory."""
+        diporder = DiporderCylinder(self.atomgroup, bin_width=0.5)
+        diporder.run()

--- a/benchmarks/modules/bench_dipordersphere.py
+++ b/benchmarks/modules/bench_dipordersphere.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.DiporderSphere`."""
+
+import MDAnalysis as mda
+
+from maicos import DiporderSphere
+from tests.data import WATER_TPR_NPT, WATER_TRR_NPT
+
+
+class DiporderSphereBenchmark:
+    """Benchmark the DiporderSphere class."""
+
+    timeout = 120
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(WATER_TPR_NPT, WATER_TRR_NPT)
+        self.atomgroup = self.universe.select_atoms("resname SOL")
+
+    def time_diporder_sphere_run(self):
+        """Benchmark DiporderSphere.run() over the trajectory."""
+        diporder = DiporderSphere(self.atomgroup, bin_width=0.5)
+        diporder.run()

--- a/benchmarks/modules/bench_pdfcylinder.py
+++ b/benchmarks/modules/bench_pdfcylinder.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.PDFCylinder`."""
+
+import MDAnalysis as mda
+
+from maicos import PDFCylinder
+from tests.data import WATER_TPR_NPT, WATER_TRR_NPT
+
+
+class PDFCylinderBenchmark:
+    """Benchmark the PDFCylinder class."""
+
+    timeout = 180
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(WATER_TPR_NPT, WATER_TRR_NPT)
+        self.atomgroup = self.universe.select_atoms("name OW")
+
+    def time_pdf_cylinder_run(self):
+        """Benchmark PDFCylinder.run() over the trajectory."""
+        pdf = PDFCylinder(self.atomgroup)
+        pdf.run()

--- a/benchmarks/modules/bench_pdfplanar.py
+++ b/benchmarks/modules/bench_pdfplanar.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.PDFPlanar`."""
+
+import MDAnalysis as mda
+
+from maicos import PDFPlanar
+from tests.data import AIRWATER_TPR, AIRWATER_TRR
+
+
+class PDFPlanarBenchmark:
+    """Benchmark the PDFPlanar class."""
+
+    timeout = 180
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(AIRWATER_TPR, AIRWATER_TRR)
+        self.atomgroup = self.universe.select_atoms("name OW")
+
+    def time_pdf_planar_run(self):
+        """Benchmark PDFPlanar.run() over the trajectory."""
+        pdf = PDFPlanar(self.atomgroup)
+        pdf.run()

--- a/benchmarks/modules/bench_temperatureplanar.py
+++ b/benchmarks/modules/bench_temperatureplanar.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.TemperaturePlanar`."""
+
+import MDAnalysis as mda
+
+from maicos import TemperaturePlanar
+from tests.data import AIRWATER_TPR, AIRWATER_TRR
+
+
+class TemperaturePlanarBenchmark:
+    """Benchmark the TemperaturePlanar class."""
+
+    timeout = 120
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(AIRWATER_TPR, AIRWATER_TRR)
+        self.atomgroup = self.universe.atoms
+
+    def time_temperature_planar_run(self):
+        """Benchmark TemperaturePlanar.run() over the trajectory."""
+        temperature = TemperaturePlanar(self.atomgroup, bin_width=0.5)
+        temperature.run()

--- a/benchmarks/modules/bench_velocitycylinder.py
+++ b/benchmarks/modules/bench_velocitycylinder.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Benchmarks for :class:`maicos.VelocityCylinder`."""
+
+import MDAnalysis as mda
+
+from maicos import VelocityCylinder
+from tests.data import WATER_TPR_NPT, WATER_TRR_NPT
+
+
+class VelocityCylinderBenchmark:
+    """Benchmark the VelocityCylinder class."""
+
+    timeout = 120
+
+    def setup(self):
+        """Set up the analysis objects."""
+        self.universe = mda.Universe(WATER_TPR_NPT, WATER_TRR_NPT)
+        self.atomgroup = self.universe.atoms
+
+    def time_velocity_cylinder_run(self):
+        """Benchmark VelocityCylinder.run() over the trajectory."""
+        velocity = VelocityCylinder(self.atomgroup, bin_width=0.5)
+        velocity.run()

--- a/benchmarks/synthetic.py
+++ b/benchmarks/synthetic.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2026 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the GNU Public Licence, v3 or any higher version
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""On-the-fly synthetic data for benchmarks.
+
+Builds a multi-frame :class:`MDAnalysis.Universe` entirely in memory (no disk I/O) so
+that framework and profile benchmarks do not depend on bundled trajectory files.
+"""
+
+import MDAnalysis as mda
+import numpy as np
+from MDAnalysis.coordinates.memory import MemoryReader
+
+
+def make_universe(
+    n_atoms: int = 3000,
+    n_frames: int = 10,
+    n_residues: int = 1000,
+    box: float = 50.0,
+    seed: int = 0,
+):
+    """Create an in-memory :class:`MDAnalysis.AtomGroup` for benchmarking.
+
+    The universe carries masses, net-neutral per-residue charges, atom types and
+    per-frame velocities, and a cubic box of edge length ``box`` for every frame.
+
+    Parameters
+    ----------
+    n_atoms : int
+        total number of atoms.
+    n_frames : int
+        number of trajectory frames.
+    n_residues : int
+        number of residues; ``n_atoms`` is distributed evenly across them.
+    box : float
+        cubic box edge length in Angstrom.
+    seed : int
+        seed for the random number generator (deterministic output).
+    """
+    rng = np.random.default_rng(seed)
+
+    resindices = np.repeat(np.arange(n_residues), n_atoms // n_residues)
+    # pad the tail so every atom maps to a residue when n_atoms is not divisible
+    if resindices.size < n_atoms:
+        pad = np.full(n_atoms - resindices.size, n_residues - 1)
+        resindices = np.concatenate([resindices, pad])
+
+    u = mda.Universe.empty(
+        n_atoms,
+        n_residues=n_residues,
+        atom_resindex=resindices,
+        trajectory=True,
+    )
+    u.add_TopologyAttr("masses", rng.uniform(1.0, 16.0, n_atoms))
+    # net-neutral charges per residue: one atom balances the rest (e.g. water-like).
+    # maicos checks neutrality per compound (here residues) for dielectric analyses.
+    counts = np.bincount(resindices, minlength=n_residues)
+    first = np.concatenate([[0], np.cumsum(counts)[:-1]])
+    charges = np.full(n_atoms, 0.5)
+    charges[first] = -0.5 * (counts - 1)
+    u.add_TopologyAttr("charges", charges)
+    u.add_TopologyAttr("types", ["O"] * n_atoms)
+
+    positions = rng.uniform(0.0, box, size=(n_frames, n_atoms, 3)).astype(np.float32)
+    velocities = rng.normal(size=(n_frames, n_atoms, 3)).astype(np.float32)
+    dimensions = np.tile([box, box, box, 90.0, 90.0, 90.0], (n_frames, 1))
+
+    u.load_new(
+        positions,
+        format=MemoryReader,
+        velocities=velocities,
+        dimensions=dimensions,
+    )
+    return u.atoms

--- a/benchmarks/synthetic.py
+++ b/benchmarks/synthetic.py
@@ -7,26 +7,28 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """On-the-fly synthetic data for benchmarks.
 
-Builds a multi-frame :class:`MDAnalysis.Universe` entirely in memory (no disk I/O) so
-that framework and profile benchmarks do not depend on bundled trajectory files.
+Builds a multi-frame :class:`MDAnalysis.Universe` of three-site molecules entirely in
+memory (no disk I/O) so that framework and profile benchmarks do not depend on bundled
+trajectory files.
 """
 
 import MDAnalysis as mda
 import numpy as np
 from MDAnalysis.coordinates.memory import MemoryReader
 
+VOLUME_PER_MOLECULE = 30.0
+MASSES = [15.999, 1.008, 1.008]
+CHARGES = [-0.8476, 0.4238, 0.4238]
 
-def make_universe(
-    n_atoms: int = 3000,
-    n_frames: int = 10,
-    n_residues: int = 1000,
-    box: float = 50.0,
-    seed: int = 0,
-):
+
+def make_universe(n_atoms: int = 3000, n_frames: int = 10, seed: int = 0):
     """Create an in-memory :class:`MDAnalysis.AtomGroup` for benchmarking.
 
-    The universe carries masses, net-neutral per-residue charges, atom types and
-    per-frame velocities, and a cubic box of edge length ``box`` for every frame.
+    Atoms are grouped into net-neutral, water-like molecules of one oxygen bonded to
+    two hydrogens sitting 1 Å away in random directions. The bonds are what let MAiCoS
+    unwrap and wrap by compound, and the random orientations keep the molecular dipoles
+    non-degenerate. ``n_atoms`` is rounded down to a multiple of three and the cubic box
+    grows with the system, so that the number density stays that of liquid water.
 
     Parameters
     ----------
@@ -34,45 +36,38 @@ def make_universe(
         total number of atoms.
     n_frames : int
         number of trajectory frames.
-    n_residues : int
-        number of residues; ``n_atoms`` is distributed evenly across them.
-    box : float
-        cubic box edge length in Angstrom.
     seed : int
         seed for the random number generator (deterministic output).
     """
     rng = np.random.default_rng(seed)
-
-    resindices = np.repeat(np.arange(n_residues), n_atoms // n_residues)
-    # pad the tail so every atom maps to a residue when n_atoms is not divisible
-    if resindices.size < n_atoms:
-        pad = np.full(n_atoms - resindices.size, n_residues - 1)
-        resindices = np.concatenate([resindices, pad])
+    n_molecules = n_atoms // 3
+    n_atoms = 3 * n_molecules
+    box = (VOLUME_PER_MOLECULE * n_molecules) ** (1 / 3)
 
     u = mda.Universe.empty(
         n_atoms,
-        n_residues=n_residues,
-        atom_resindex=resindices,
+        n_residues=n_molecules,
+        atom_resindex=np.repeat(np.arange(n_molecules), 3),
         trajectory=True,
     )
-    u.add_TopologyAttr("masses", rng.uniform(1.0, 16.0, n_atoms))
-    # net-neutral charges per residue: one atom balances the rest (e.g. water-like).
-    # maicos checks neutrality per compound (here residues) for dielectric analyses.
-    counts = np.bincount(resindices, minlength=n_residues)
-    first = np.concatenate([[0], np.cumsum(counts)[:-1]])
-    charges = np.full(n_atoms, 0.5)
-    charges[first] = -0.5 * (counts - 1)
-    u.add_TopologyAttr("charges", charges)
-    u.add_TopologyAttr("types", ["O"] * n_atoms)
+    u.add_TopologyAttr("masses", np.tile(MASSES, n_molecules))
+    u.add_TopologyAttr("charges", np.tile(CHARGES, n_molecules))
+    u.add_TopologyAttr("types", np.tile(["O", "H", "H"], n_molecules))
 
-    positions = rng.uniform(0.0, box, size=(n_frames, n_atoms, 3)).astype(np.float32)
-    velocities = rng.normal(size=(n_frames, n_atoms, 3)).astype(np.float32)
-    dimensions = np.tile([box, box, box, 90.0, 90.0, 90.0], (n_frames, 1))
+    oxygens: np.ndarray = np.repeat(3 * np.arange(n_molecules), 2)
+    hydrogens = oxygens + np.tile([1, 2], n_molecules)
+    u.add_TopologyAttr("bonds", np.column_stack([oxygens, hydrogens]))
+
+    sites = rng.normal(size=(n_frames, n_molecules, 3, 3))
+    sites /= np.linalg.norm(sites, axis=-1, keepdims=True)
+    sites[..., 0, :] = 0.0
+    centers = rng.uniform(0.0, box, size=(n_frames, n_molecules, 1, 3))
+    positions = (centers + sites).reshape(n_frames, n_atoms, 3).astype(np.float32)
 
     u.load_new(
         positions,
         format=MemoryReader,
-        velocities=velocities,
-        dimensions=dimensions,
+        velocities=rng.normal(size=(n_frames, n_atoms, 3)).astype(np.float32),
+        dimensions=np.tile([box, box, box, 90.0, 90.0, 90.0], (n_frames, 1)),
     )
     return u.atoms


### PR DESCRIPTION
Fixes #590

Changes made in this Pull Request:
<!-- What does this implement/fix? Explain your changes here. -->
 - Added benchmarks/synthetic.py which builds a multi-frame MDAnalysis Universe entirely in memory (Universe.empty + MemoryReader) carrying masses, per-residue net-neutral charges, atom types, and per-frame velocities, with a cubic box set on every frame. This means the framework and profile benchmarks no longer depend on bundled trajectory files.
- Tries to make benchmarks/core/bench_base.py runnable. The previous AnalysisBaseBenchmark was effectively a stub — it had no setup or time_* methods, and its self._obs.data = ... collided with MDAnalysis Results' internal storage, so ASV never ran it? I think. It now provides three benchmarks: AnalysisBaseBenchmark for direct framework overhead of a bare run(), ObsAccumulationBenchmark for the cost of accumulating an increasing number of _obs keys (1, 10, 100, 1000), and SingleFrameBenchmark for the marginal cost of each per-frame transform (none, pack, unwrap, refgroup).
- Added benchmarks/core/bench_profile.py with bin-dependent benchmarks that sweep number of bins for a ProfileBase path (DensityPlanar) and a Dielectric path (DielectricPlanar), both on synthetic data.
- Added benchmarks for the active modules that were previously uncovered: DiporderCylinder, DiporderSphere, TemperaturePlanar, VelocityCylinder, PDFPlanar, and PDFCylinder. (this can be improved its fairly simple rn)

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Docs?
 - [x] Issue raised/referenced?


## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
 - [x] LLMs or other AI-powered tools (beyond simple code suggestions e.g. inside IDEs) were used in this contribution.


<!-- readthedocs-preview maicos start -->
----
📚 Documentation preview 📚: https://maicos--595.org.readthedocs.build/en/595/

<!-- readthedocs-preview maicos end -->